### PR TITLE
fix: eliminate extra transition on Safari and Firefox

### DIFF
--- a/src/grid/grid.tsx
+++ b/src/grid/grid.tsx
@@ -25,8 +25,17 @@ export interface ExpandableGridProps {
   onDeselect?: () => void;
 }
 
+interface SelectionState {
+  selectedId?: string;
+  shouldTransition: boolean;
+}
+
 export function ExpandableGrid(props: ExpandableGridProps) {
-  const { selectedId } = props;
+  const externalSelectedId = props.selectedId;
+  const [selectionState, setSelectionState] = React.useState<SelectionState>({
+    selectedId: 'never',
+    shouldTransition: true,
+  });
   const gridRef = React.createRef<HTMLUListElement>();
   const [width, setWidth] = React.useState<number | null>(null);
 
@@ -46,6 +55,7 @@ export function ExpandableGrid(props: ExpandableGridProps) {
     };
   }, [resizeFn]);
 
+  /*
   const prevSelectedId = React.useRef<undefined | string>(selectedId);
   React.useLayoutEffect(() => {
     const prevId = prevSelectedId.current;
@@ -57,9 +67,24 @@ export function ExpandableGrid(props: ExpandableGridProps) {
       prevSelectedId.current = selectedId;
     }
   }, [gridRef, selectedId]);
+  */
+
+  React.useEffect(() => {
+    const prevId = selectionState.selectedId;
+    const selectedId = externalSelectedId;
+
+    // Only animate opening/closing
+    const shouldTransition = prevId === undefined || selectedId === undefined;
+    setSelectionState({ selectedId, shouldTransition });
+  }, [externalSelectedId]);
 
   return (
-    <ul className="og-grid" ref={gridRef}>
+    <ul
+      className={classNames('og-grid', {
+        'og-transitionable': selectionState.shouldTransition,
+      })}
+      ref={gridRef}
+    >
       {width === null ? null : (
         <GridWithWidth {...props} containerWidth={width} />
       )}

--- a/src/grid/grid.tsx
+++ b/src/grid/grid.tsx
@@ -55,20 +55,6 @@ export function ExpandableGrid(props: ExpandableGridProps) {
     };
   }, [resizeFn]);
 
-  /*
-  const prevSelectedId = React.useRef<undefined | string>(selectedId);
-  React.useLayoutEffect(() => {
-    const prevId = prevSelectedId.current;
-    if (prevId !== selectedId) {
-      // console.log('selected ID changed', prevId, '->', selectedId);
-      // Only animate opening/closing
-      const shouldTransition = prevId === undefined || selectedId === undefined;
-      gridRef.current?.classList.toggle('og-transitionable', shouldTransition);
-      prevSelectedId.current = selectedId;
-    }
-  }, [gridRef, selectedId]);
-  */
-
   React.useEffect(() => {
     const prevId = selectionState.selectedId;
     const selectedId = externalSelectedId;
@@ -86,7 +72,11 @@ export function ExpandableGrid(props: ExpandableGridProps) {
       ref={gridRef}
     >
       {width === null ? null : (
-        <GridWithWidth {...props} containerWidth={width} />
+        <GridWithWidth
+          {...props}
+          selectedId={selectionState.selectedId}
+          containerWidth={width}
+        />
       )}
     </ul>
   );


### PR DESCRIPTION
Fixes #17 

Going from image to image requires another effect to fire now, but the transitions all seem to be correct.