### PR TITLE
show loading indicator for grid

### DIFF
--- a/src/Slideshow.tsx
+++ b/src/Slideshow.tsx
@@ -154,7 +154,7 @@ export function Slideshow(props: SlideshowProps) {
     [onResetYears],
   );
 
-  return images ? (
+  return (
     <div id="expanded">
       <div className="curtains" onClick={handleExit}></div>
 
@@ -209,17 +209,21 @@ export function Slideshow(props: SlideshowProps) {
       </div>
 
       <div id="grid-container" onClick={exitIfSelfClick}>
-        <ExpandableGrid
-          images={images}
-          rowHeight={200}
-          speed={200}
-          selectedId={selectedPhotoId}
-          imageEl={ImagePreview}
-          details={DetailView}
-          onSelect={handleSelect}
-          onDeselect={handleDeselect}
-        />
+        {images ? (
+          <ExpandableGrid
+            images={images}
+            rowHeight={200}
+            speed={200}
+            selectedId={selectedPhotoId}
+            imageEl={ImagePreview}
+            details={DetailView}
+            onSelect={handleSelect}
+            onDeselect={handleDeselect}
+          />
+        ) : (
+          <div className="grid-loading">Loading…</div>
+        )}
       </div>
     </div>
-  ) : null;
+  );
 }

--- a/styles/viewer.css
+++ b/styles/viewer.css
@@ -155,6 +155,10 @@ h2 a {
   overflow-y: scroll;
 }
 
+#grid-container .grid-loading {
+  color: white;
+}
+
 #expanded-controls {
   position: fixed;
   top: 55px;


### PR DESCRIPTION
Fixes https://github.com/danvk/oldnyc/issues/23

Even for users on fast connections, this has the benefit of rendering most of the slideshow UI while the lat/lng JSON is loading.