### PR TITLE
hide highway signs and traffic lights

### DIFF
--- a/src/map-styles.ts
+++ b/src/map-styles.ts
@@ -1,6 +1,6 @@
 // Styles for Google Maps. These de-emphasize features on the map.
+// https://mapstyle.withgoogle.com/
 export const MAP_STYLE: google.maps.MapTypeStyle[] = [
-  // to remove buildings
   { stylers: [{ visibility: 'off' }] },
   { featureType: 'water', stylers: [{ visibility: 'simplified' }] },
   { featureType: 'poi', stylers: [{ visibility: 'simplified' }] },
@@ -8,7 +8,7 @@ export const MAP_STYLE: google.maps.MapTypeStyle[] = [
   { featureType: 'landscape', stylers: [{ visibility: 'simplified' }] },
   { featureType: 'road', stylers: [{ visibility: 'simplified' }] },
   { featureType: 'administrative', stylers: [{ visibility: 'simplified' }] },
-  // end remove buildings
+
   {
     featureType: 'administrative',
     elementType: 'labels',
@@ -99,6 +99,36 @@ export const MAP_STYLE: google.maps.MapTypeStyle[] = [
   {
     featureType: 'water',
     elementType: 'labels',
+    stylers: [
+      {
+        visibility: 'off',
+      },
+    ],
+  },
+
+  // Hide highway icons
+  {
+    featureType: 'road.arterial',
+    elementType: 'labels.icon',
+    stylers: [
+      {
+        visibility: 'off',
+      },
+    ],
+  },
+  {
+    featureType: 'road.highway',
+    elementType: 'labels.icon',
+    stylers: [
+      {
+        visibility: 'off',
+      },
+    ],
+  },
+  // hide traffic lights
+  {
+    featureType: 'road',
+    elementType: 'labels.icon',
     stylers: [
       {
         visibility: 'off',


### PR DESCRIPTION
Fixes https://github.com/danvk/oldnyc/issues/92

This also gets rid of the weird gray smudges where there are traffic lights:
![image](https://github.com/user-attachments/assets/36c5b2d1-b7b2-4629-824a-7865ec0e5c0f)
