### PR TITLE
Allow unsuffixed photo IDs in URLs

### DIFF
--- a/src/Slideshow.tsx
+++ b/src/Slideshow.tsx
@@ -120,7 +120,6 @@ export function Slideshow(props: SlideshowProps) {
       selectedImage.id !== selectedPhotoId &&
       selectedImage.id.startsWith(selectedPhotoId)
     ) {
-      console.log('Redirecting from', selectedPhotoId, '->', selectedImage.id);
       history.replace(`/${selectedImage.id}`);
     }
   }, [history, selectedImage, selectedPhotoId]);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -58,7 +58,6 @@ function PhotoApp() {
   if (photoId && !loc) {
     loc = photoIdToLatLon[photoId];
   }
-  console.log(photoId, 'loc', loc);
 
   // TODO: make sure there's only one request in flight for any id4
   const [, setForceUpdate] = React.useState(0);


### PR DESCRIPTION
Fixes #39 

This allows you to visit https://www.oldnyc.org/#731896f, for example, and be redirected to https://www.oldnyc.org/#731896f-a. This is mostly useless for users of the site, but is wildly helpful for me when working on geocoding, which doesn't care about the cropping suffixes.

This would also make it easier for the NYPL to link to OldNYC, should they ever choose to do that.